### PR TITLE
[Fixed]`rails g`コマンドの際に不要なassetsファイル、helperファイルが生成されないように改善

### DIFF
--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -16,5 +16,4 @@
     <%= link_to 'お気に入りする', favorites_path(blog_id: @blog.id), method: :post, class: 'btn btn-primary' %>
   <% end %>
 <% end %>
-
 <%= link_to "ブログ一覧画面にもどる", blogs_path, class: 'btn btn-info' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module FbcloneApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1 

修正箇所
- config/application.rbファイルに追記